### PR TITLE
Use 'authentication' instead of 'auth' when setting options

### DIFF
--- a/src/restrict-to-roles.js
+++ b/src/restrict-to-roles.js
@@ -30,7 +30,7 @@ export default function (options = {}) {
       throw new errors.NotAuthenticated();
     }
 
-    options = Object.assign({}, defaults, hook.app.get('auth'), options);
+    options = Object.assign({}, defaults, hook.app.get('authentication'), options);
 
     let authorized = false;
     let roles = get(hook.params.user, options.fieldName);


### PR DESCRIPTION
Closes #13 
