### PR TITLE
Changed hooks to use `hook.service` instead of `this`

### DIFF
--- a/src/has-role-or-restrict.js
+++ b/src/has-role-or-restrict.js
@@ -53,7 +53,7 @@ export default function (options = {}) {
         return hook;
       }
 
-      return this.find({ query }, params).then(results => {
+      return hook.service.find({ query }, params).then(results => {
         if (hook.method === 'get' && Array.isArray(results) && results.length === 1) {
           hook.result = results[0];
           return hook;
@@ -103,7 +103,7 @@ export default function (options = {}) {
         // set on the resource we are requesting.
         const params = Object.assign({}, hook.params, { provider: undefined });
 
-        this.get(hook.id, params).then(data => {
+        hook.service.get(hook.id, params).then(data => {
           if (data.toJSON) {
             data = data.toJSON();
           } else if (data.toObject) {
@@ -131,7 +131,7 @@ export default function (options = {}) {
         return hook;
       }
 
-      return this.find({ query }, params).then(results => {
+      return hook.service.find({ query }, params).then(results => {
         if (hook.method === 'get' && Array.isArray(results) && results.length === 1) {
           hook.result = results[0];
           return hook;

--- a/src/restrict-to-owner.js
+++ b/src/restrict-to-owner.js
@@ -50,7 +50,7 @@ export default function (options = {}) {
     // set on the resource we are requesting.
     const params = Object.assign({}, hook.params, { provider: undefined });
 
-    return this.get(hook.id, params).then(data => {
+    return hook.service.get(hook.id, params).then(data => {
       if (data.toJSON) {
         data = data.toJSON();
       } else if (data.toObject) {

--- a/src/restrict-to-roles.js
+++ b/src/restrict-to-roles.js
@@ -72,7 +72,7 @@ export default function (options = {}) {
       // set on the resource we are requesting.
       const params = Object.assign({}, hook.params, { provider: undefined });
 
-      return this.get(hook.id, params).then(data => {
+      return hook.service.get(hook.id, params).then(data => {
         if (data.toJSON) {
           data = data.toJSON();
         } else if (data.toObject) {

--- a/test/has-role-or-restrict.test.js
+++ b/test/has-role-or-restrict.test.js
@@ -81,9 +81,9 @@ describe('hasRoleOrRestrict', () => {
     it('should merge the restriction in to the query and call find', () => {
       let hook = {
         app: {
-          service: mockService,
           get: function () {}
         },
+        service: MockService,
         method: 'find',
         type: 'before',
         params: {
@@ -100,9 +100,9 @@ describe('hasRoleOrRestrict', () => {
       let hook = {
         id: '525235',
         app: {
-          service: MockService,
           get: function () {}
         },
+        service: MockService,
         method: 'find',
         type: 'before',
         params: {
@@ -132,7 +132,8 @@ describe('hasRoleOrRestrict', () => {
         },
         app: {
           get: function () { return {}; }
-        }
+        },
+        service: MockService
       };
     });
 
@@ -171,9 +172,9 @@ describe('hasRoleOrRestrict', () => {
       it('should merge the restriction in to the query and call find', () => {
         let hook = {
           app: {
-            service: mockService,
             get: function () {}
           },
+          service: MockService,
           method: 'find',
           type: 'before',
           params: {
@@ -191,9 +192,9 @@ describe('hasRoleOrRestrict', () => {
           id: '525235',
           method: 'find',
           app: {
-            service: MockService,
             get: function () {}
           },
+          service: MockService,
           type: 'before',
           params: {
             provider: 'rest'
@@ -276,7 +277,8 @@ describe('hasRoleOrRestrict', () => {
           },
           app: {
             get: function () { return {}; }
-          }
+          },
+          service: MockService
         };
       });
 

--- a/test/restrict-to-owner.test.js
+++ b/test/restrict-to-owner.test.js
@@ -111,7 +111,8 @@ describe('restrictToOwner', () => {
           provider: 'rest',
           user: { _id: '1' }
         },
-        app
+        app,
+        service: MockService
       };
     });
 

--- a/test/restrict-to-roles.test.js
+++ b/test/restrict-to-roles.test.js
@@ -100,7 +100,8 @@ describe('restrictToRoles', () => {
         },
         app: {
           get: function () { return {}; }
-        }
+        },
+        service: MockService
       };
     });
 


### PR DESCRIPTION
### Summary

This fixes the problem that hooks lose context of this when used inside
other hooks.

* Fixes #17: Hook "restrictToOwner" looses context (this) when wrapped

### Other Information

Since I haven't contributed to feathers that much, I am not sure if this change is breaking something in older versions. This change depends on that, the hook object contains a service object, that provides the functionality to find, get, create, etc. of the current service that the hook is in.

The tests created the mock service under `hook.app` and I have now moved it under the `hook` object.