### PR TITLE
Update associate-current-user.js

### DIFF
--- a/src/associate-current-user.js
+++ b/src/associate-current-user.js
@@ -31,7 +31,11 @@ export default function (options = {}) {
     function setId (obj) {
       set(obj, options.as, id);
     }
-
+    
+    if (!hook.data) {
+      hook.data = {};
+    }
+    
     // Handle arrays.
     if (Array.isArray(hook.data)) {
       hook.data.forEach(setId);


### PR DESCRIPTION
Associating a user without a data object doesn't work (e.g. if you have a table with only ID references). I solved it by checking whether the hook.data object is present.

