### PR TITLE
Add `expandPaths` option to en/disable `options.as` path expansion

### DIFF
--- a/src/query-with-current-user.js
+++ b/src/query-with-current-user.js
@@ -3,7 +3,8 @@ import set from 'lodash.set';
 
 const defaults = {
   idField: '_id',
-  as: 'userId'
+  as: 'userId',
+  expandPaths: true
 };
 
 export default function (options = {}) {
@@ -28,6 +29,9 @@ export default function (options = {}) {
       throw new Error(`Current user is missing '${options.idField}' field.`);
     }
 
-    set(hook.params, `query.${options.as}`, id);
+    if (defaults.expandPaths) {
+      set(hook.params, `query.${options.as}`, id);
+    } else {
+      hook.params.query[optioins.as] = id;
   };
 }

--- a/src/query-with-current-user.js
+++ b/src/query-with-current-user.js
@@ -29,9 +29,10 @@ export default function (options = {}) {
       throw new Error(`Current user is missing '${options.idField}' field.`);
     }
 
-    if (defaults.expandPaths) {
+    if (options.expandPaths) {
       set(hook.params, `query.${options.as}`, id);
     } else {
-      hook.params.query[optioins.as] = id;
+      hook.params.query[options.as] = id;
+    }
   };
 }

--- a/src/restrict-to-owner.js
+++ b/src/restrict-to-owner.js
@@ -5,7 +5,8 @@ import queryWithCurrentUser from './query-with-current-user';
 
 const defaults = {
   idField: '_id',
-  ownerField: 'userId'
+  ownerField: 'userId',
+  expandPaths: true
 };
 
 export default function (options = {}) {
@@ -24,7 +25,8 @@ export default function (options = {}) {
     if (hook.method === 'find' || hook.id === null) {
       return queryWithCurrentUser({
         idField: options.idField,
-        as: options.ownerField
+        as: options.ownerField,
+        expandPaths: options.expandPaths
       })(hook);
     }
 


### PR DESCRIPTION
### Summary

This is an attempt to fix for the issue identified in #22 where nested query properties aren't supported by some DB adapters (namely Mongoose and RethinkDB).

The fix simply adds a new `expandPaths` option to both the `queryWithCurrentUser` and `restrictToOwner` hooks. `expandPaths` defaults to true to preserve current behaviour. `restrictToOwner` simply passes the `expandPaths` option to `queryWithCurrentUser` for `find` operations.